### PR TITLE
Implement AnswerMessageListener with Unit Tests

### DIFF
--- a/QuestionBot/QuestionBot.UnitTests/Model/AnswerMessageListenerTests.cs
+++ b/QuestionBot/QuestionBot.UnitTests/Model/AnswerMessageListenerTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using NUnit.Framework;
+using QuestionBot.Model;
+using Moq;
+
+
+namespace QuestionBot.UnitTests.Model {
+    [TestFixture]
+    class AnswerMessageListenerTests {
+        private IMessageListener _testListener;
+        private Mock< IStore > _storeTest;
+
+        [SetUp]
+        public void Setup() {
+            _storeTest = new Mock< IStore >( MockBehavior.Strict );
+            _testListener = new AnswerMessageListener( _storeTest.Object );
+        }
+
+        [Test]
+        [TestCase( "The answer is 3." )]
+        [TestCase( "I forget the /answer" )]
+        public void Valid_id_and_answer_updates_record( string answerText ) {
+            const int id = 15;
+            string fullAnswer = "/answer " + id + " " + answerText;
+
+            IRecord record = new Record( id, "What is 1+2?", DateTime.Now );
+
+            _storeTest.Setup( x => x.TryUpdateRecord( id, answerText, out record ) )
+                .Returns( true );
+
+            string response = _testListener.ReceiveMessage( fullAnswer );
+
+            Assert.AreEqual( "Question with ID <" + id + "> has been updated with your answer: " +
+                             answerText, response );
+
+            _storeTest.Verify( x => x.TryUpdateRecord( id, answerText, out record ), Times.Exactly( 1 ) );
+        }
+
+        [Test]
+        [TestCase( "/answer 1" )]
+        [TestCase( "/answer 1 \n\t     " )]
+        public void Blank_answer_does_not_update_record_returns_error( string emptyAnswer ) {
+            string response = _testListener.ReceiveMessage( emptyAnswer );
+
+            Assert.AreEqual( AnswerMessageListener.ErrorMessage, response );
+        }
+
+        [Test]
+        [TestCase( null )]
+        [TestCase( "this doesn't start with /answer" )]
+        [TestCase( "" )]
+        [TestCase( " /answer there is a space before /answer" )]
+        public void Null_or_bad_input_does_nothing( string badInput ) {
+            string response = _testListener.ReceiveMessage( badInput );
+
+            Assert.IsNull( response );
+        }
+
+
+        [Test]
+        [TestCase( "    The answer is 3.    ", "The answer is 3." )]
+        [TestCase( "\tThe answer is 3.\t", "The answer is 3." )]
+        [TestCase( "\nThe answer is 3.\n", "The answer is 3." )]
+        public void Starting_and_trailing_whitespace_is_removed_from_answer( string actualAnswer,
+            string actualAnswerTrimmed ) {
+            const int id = 15;
+            string fullAnswer = "/answer " + id + " " + actualAnswer;
+            IRecord record = new Record( id, "What is 1+2?", DateTime.Now );
+
+            _storeTest.Setup( x => x.TryUpdateRecord( id, actualAnswerTrimmed, out record ) ).Returns( true );
+
+            string response = _testListener.ReceiveMessage( fullAnswer );
+
+            Assert.AreEqual( "Question with ID <" + id + "> has been updated with your answer: " + actualAnswerTrimmed,
+                response );
+            _storeTest.Verify( x => x.TryUpdateRecord( id, actualAnswerTrimmed, out record ), Times.Exactly( 1 ) );
+        }
+
+        [Test]
+        [TestCase( "/answer The answer is 3." )]
+        [TestCase( "/answer 1The answer is 3." )]
+        public void Update_question_with_no__or_bad_answer_id_returns_error( string fullAnswer ) {
+            string response = _testListener.ReceiveMessage( fullAnswer );
+
+            Assert.AreEqual( AnswerMessageListener.ErrorMessage, response );
+        }
+    }
+}

--- a/QuestionBot/QuestionBot.UnitTests/Model/QuestionMessageListenerTests.cs
+++ b/QuestionBot/QuestionBot.UnitTests/Model/QuestionMessageListenerTests.cs
@@ -57,8 +57,8 @@ namespace QuestionBot.UnitTests.Model{
 
         [Test]
         [TestCase("    What is 1+2?    ", "What is 1+2?")]
-        [TestCase("\tWhat is 1+2\t", "What is 1+2?")]
-        [TestCase("\nWhat is 1+2\n", "What is 1+2?")]
+        [TestCase("\tWhat is 1+2?\t", "What is 1+2?")]
+        [TestCase("\nWhat is 1+2?\n", "What is 1+2?")]
         public void Starting_and_trailing_whitespace_is_removed_from_question(string actualQuestion, string actualQuestionTrimmed)
         {
             string question = "/question " + actualQuestion;

--- a/QuestionBot/QuestionBot.UnitTests/QuestionBot.UnitTests.csproj
+++ b/QuestionBot/QuestionBot.UnitTests/QuestionBot.UnitTests.csproj
@@ -46,9 +46,11 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Model\AnswerMessageListenerTests.cs" />
     <Compile Include="Model\MessageEmitterTests.cs" />
     <Compile Include="Model\InMemoryStoreTests.cs" />
     <Compile Include="Model\QuestionMessageListenerTests.cs" />
+    <Compile Include="MoqExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/QuestionBot/QuestionBot/Model/AnswerMessageListener.cs
+++ b/QuestionBot/QuestionBot/Model/AnswerMessageListener.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuestionBot.Model {
+    class AnswerMessageListener : IMessageListener {
+        private const string AnswerCommand = "/answer";
+        public const string ErrorMessage = "This answer or ID appears to be blank, please retry.";
+        private IStore _answerDataStore;
+
+
+        public AnswerMessageListener( IStore store ) {
+            _answerDataStore = store;
+        }
+
+        public string ReceiveMessage( string message ) {
+            string words = "a";
+            IRecord questionRecord;
+            int id;
+
+            if ( String.IsNullOrEmpty( message ) || !message.StartsWith( AnswerCommand ) ) {
+                return null;
+            }
+
+            string idWithAnswerText = message.Remove( 0, AnswerCommand.Length );
+            string[] splitIdWithAnswer = idWithAnswerText.Split( null );
+
+            if ( splitIdWithAnswer.Count() < 2 ) {
+                return ErrorMessage;
+            }
+
+            Int32.TryParse( splitIdWithAnswer[0], out id );
+            string answer = splitIdWithAnswer[1];
+
+            _answerDataStore.TryUpdateRecord( id, answer, out questionRecord );
+            outputMessage = "Question with ID " + id + " has been updated with your answer: " +
+                            answer;
+            return "";
+        }
+    }
+}

--- a/QuestionBot/QuestionBot/Program.cs
+++ b/QuestionBot/QuestionBot/Program.cs
@@ -5,10 +5,12 @@ namespace QuestionBot.Model {
         private static void Main( string[] args ) {
             IStore localStore = new InMemoryStore();
             IMessageListener questionListener = new QuestionMessageListener(localStore);
+            IMessageListener answerMessageListener = new AnswerMessageListener(localStore);
             IConsole consoleWrapper = new ConsoleWrapper();
             IMessageEmitter emitter = new MessageEmitter(consoleWrapper);
 
             emitter.Add(questionListener);
+            emitter.Add(answerMessageListener);
             emitter.Start();
         }
     }

--- a/QuestionBot/QuestionBot/QuestionBot.csproj
+++ b/QuestionBot/QuestionBot/QuestionBot.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Model\AnswerMessageListener.cs" />
     <Compile Include="Model\ConsoleWrapper.cs" />
     <Compile Include="Model\IConsole.cs" />
     <Compile Include="Model\IMessageEmitter.cs" />


### PR DESCRIPTION
Implement AnswerMessageListener with Unit Tests

Still to do:
Create a class ListMessageListener which implements IMessageListener.
The constructor of ListMessageListener should take an IStore as a parameter.
ListMessageListener.ReceiveMessage should listen for messages of the form /list
If such a message is received, ListMessageListener should return a human friendly representation of all questions/answers in the IStore.
Write unit tests for ListMessageListener. You will need to use Moq to create a fake IStore to test with.